### PR TITLE
[FIX] NameError: global name 'currency_rate' is not defined

### DIFF
--- a/hr_expense_multicurrencies/hr_expense.py
+++ b/hr_expense_multicurrencies/hr_expense.py
@@ -51,7 +51,7 @@ class hr_expense_line(orm.Model):
         
         for record in self.browse(cr, uid, ids, context=context):
             if record.currency_rate and record.currency_rate != 0:
-                res[record.id] /= currency_rate
+                res[record.id] /= record.currency_rate
         return res
 
     def _get_currency_rate(self, cr, uid, ids, field_name, arg, context=None):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 132, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 199, in execute
    res = self.execute_cr(cr, uid, obj, method, *args, **kw)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 187, in execute_cr
    return getattr(object, method)(cr, uid, *args, **kw)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/orm.py", line 3693, in read
    result = self._read_flat(cr, user, select, fields, context, load)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/orm.py", line 3816, in _read_flat
    res2 = self._columns[f].get(cr, self, ids, f, user, context=context, values=res)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/fields.py", line 1152, in get
    result = self._fnct(obj, cr, uid, ids, name, self._arg, context)
  File "/home/andrea/workspace/Odoo/7.0/src/third-party/hr_expense_multicurrencies/hr_expense.py", line 54, in _amount
    res[record.id] /= currency_rate
NameError: global name 'currency_rate' is not defined
2014-10-28 09:23:00,483 10692 ERROR nadia_collaudo_1 openerp.netsvc: global name 'currency_rate' is not defined
Traceback (most recent call last):
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/netsvc.py", line 296, in dispatch_rpc
    result = ExportService.getService(service_name).dispatch(method, params)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/service/web_services.py", line 626, in dispatch
    res = fn(db, uid, *params)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 190, in execute_kw
    return self.execute(db, uid, obj, method, *args, **kw or {})
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 132, in wrapper
    return f(self, dbname, *args, **kwargs)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 199, in execute
    res = self.execute_cr(cr, uid, obj, method, *args, **kw)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/osv.py", line 187, in execute_cr
    return getattr(object, method)(cr, uid, *args, **kw)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/orm.py", line 3693, in read
    result = self._read_flat(cr, user, select, fields, context, load)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/orm.py", line 3816, in _read_flat
    res2 = self._columns[f].get(cr, self, ids, f, user, context=context, values=res)
  File "/home/andrea/workspace/Odoo/7.0/src/openerp/openerp/osv/fields.py", line 1152, in get
    result = self._fnct(obj, cr, uid, ids, name, self._arg, context)
  File "/home/andrea/workspace/Odoo/7.0/src/third-party/hr_expense_multicurrencies/hr_expense.py", line 54, in _amount
    res[record.id] /= currency_rate
```
