### PR TITLE
Porting product tags to v8

### DIFF
--- a/product_tags/__openerp__.py
+++ b/product_tags/__openerp__.py
@@ -37,7 +37,7 @@
         'security/ir.model.access.csv',
         'product_view.xml',
     ],
-    'installable' : False,
+    'installable' : True,
     'active' : False,
 }
 

--- a/product_tags/__openerp__.py
+++ b/product_tags/__openerp__.py
@@ -3,18 +3,19 @@
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
+#    Copyright (C) 2015 credativ ltd. <info@credativ.co.uk>
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
+#    GNU Affero General Public License for more details.
 #
-#    You should have received a copy of the GNU General Public License
+#    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #################################################################################

--- a/product_tags/product.py
+++ b/product_tags/product.py
@@ -19,20 +19,54 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #################################################################################
-from openerp.osv import fields, orm
-from openerp.tools.translate import _
+from openerp import models, fields, api, _
 
-class product_tag(orm.Model):
+class product_tag(models.Model):
+    _description = 'Product Tags'
     _name = "product.tag"
-    _columns = {
-        'name': fields.char('Tag Name', required=True, size=64),
-    }
 
-class product_product(orm.Model):
-    _inherit = "product.product"
-    
-    _columns = {
-        'tag_ids' : fields.many2many('product.tag', 'product_product_tag_rel', 'tag_id', 'product_id', 'Tags'),
-    }
-    
+    # this should be the default according to the documentation, but no such
+    # thing is done in the actual implementation
+    _rec_name = 'display_name'
+
+    name = fields.Char('Tag Name', required=True, translate=True)
+    display_name = fields.Char('Full Name', compute='_compute_display_name')
+    active = fields.Boolean(help='The active field allows you to hide the tag without removing it.', default=True)
+    parent = fields.Many2one(string='Parent Tag', comodel_name='product.tag', select=True, ondelete='cascade')
+    child_ids = fields.One2many(string='Child Tags', comodel_name='product.tag', inverse_name='parent')
+    parent_left = fields.Integer('Left Parent', select=True)
+    parent_right = fields.Integer('Right Parent', select=True)
+
+    _parent_store = True
+    _parent_order = 'name'
+    _order = 'parent_left'
+
+    @api.one
+    @api.depends('name', 'parent.name')
+    def _compute_display_name(self):
+        """ Return the tags' display name, including their direct parent. """
+        if self.parent:
+            self.display_name = self.parent.display_name + ' / ' + self.name
+        else:
+            self.display_name = self.name
+
+    @api.model
+    def name_search(self, name, args=None, operator='ilike', limit=100):
+        args = args or []
+        if name:
+            # Be sure name_search is symetric to name_get
+            name = name.split(' / ')[-1]
+            args = [('name', operator, name)] + args
+        tags = self.search(args, limit=limit)
+        return tags.name_get()
+
+class product_template(models.Model):
+    _inherit = "product.template"
+
+    tag_ids = fields.Many2many(string='Tags',
+                               comodel_name='product.tag',
+                               relation='product_product_tag_rel',
+                               column1='tag_id',
+                               column2='product_id')
+
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/product_tags/product.py
+++ b/product_tags/product.py
@@ -32,8 +32,8 @@ class product_tag(models.Model):
     name = fields.Char('Tag Name', required=True, translate=True)
     display_name = fields.Char('Full Name', compute='_compute_display_name')
     active = fields.Boolean(help='The active field allows you to hide the tag without removing it.', default=True)
-    parent = fields.Many2one(string='Parent Tag', comodel_name='product.tag', select=True, ondelete='cascade')
-    child_ids = fields.One2many(string='Child Tags', comodel_name='product.tag', inverse_name='parent')
+    parent_id = fields.Many2one(string='Parent Tag', comodel_name='product.tag', select=True, ondelete='cascade')
+    child_ids = fields.One2many(string='Child Tags', comodel_name='product.tag', inverse_name='parent_id')
     parent_left = fields.Integer('Left Parent', select=True)
     parent_right = fields.Integer('Right Parent', select=True)
 
@@ -42,11 +42,11 @@ class product_tag(models.Model):
     _order = 'parent_left'
 
     @api.one
-    @api.depends('name', 'parent.name')
+    @api.depends('name', 'parent_id.name')
     def _compute_display_name(self):
         """ Return the tags' display name, including their direct parent. """
-        if self.parent:
-            self.display_name = self.parent.display_name + ' / ' + self.name
+        if self.parent_id:
+            self.display_name = self.parent_id.display_name + ' / ' + self.name
         else:
             self.display_name = self.name
 

--- a/product_tags/product.py
+++ b/product_tags/product.py
@@ -3,18 +3,19 @@
 #
 #    OpenERP, Open Source Management Solution
 #    Copyright (C) 2013 Julius Network Solutions SARL <contact@julius.fr>
+#    Copyright (C) 2015 credativ ltd. <info@credativ.co.uk>
 #
 #    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU General Public License as published by
-#    the Free Software Foundation, either version 3 of the License, or
-#    (at your option) any later version.
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
 #
 #    This program is distributed in the hope that it will be useful,
 #    but WITHOUT ANY WARRANTY; without even the implied warranty of
 #    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU General Public License for more details.
+#    GNU Affero General Public License for more details.
 #
-#    You should have received a copy of the GNU General Public License
+#    You should have received a copy of the GNU Affero General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 #################################################################################

--- a/product_tags/product_view.xml
+++ b/product_tags/product_view.xml
@@ -6,8 +6,12 @@
             <field name="name">product.tag.view.form</field>
             <field name="model">product.tag</field>
             <field name="arch" type="xml">
-                <form string="Tag">
-                    <field name="name"/>
+                <form string="Product Tag">
+                    <group col="4">
+                        <field name="name"/>
+                        <field name="active"/>
+                        <field name="parent"/>
+                    </group>
                 </form>
             </field>
         </record>	
@@ -15,9 +19,21 @@
         <record id="product_tag_tree" model="ir.ui.view">
             <field name="name">product.tag.view.tree</field>
             <field name="model">product.tag</field>
+            <field name="field_parent">child_ids</field>
             <field name="arch" type="xml">
-                <tree string="Tag">
-                    <field name="name"/>
+                <tree toolbar="1" string="Product Tags">
+                    <field name="display_name"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="product_tag_list" model="ir.ui.view">
+            <field name="name">Product Tags</field>
+            <field name="model">product.tag</field>
+            <field eval="6" name="priority"/>
+            <field name="arch" type="xml">
+                <tree string="Product Tags">
+                    <field name="display_name"/>
                 </tree>
             </field>
         </record>
@@ -45,34 +61,34 @@
             id="menu_product_tag_action_form"
             parent="product.prod_config_main" sequence="3"/>
 	
-        <record id="product_product_tag_search_inherit" model="ir.ui.view">
-            <field name="name">product.product.tag.view.search</field>
-            <field name="model">product.product</field>
-            <field name="inherit_id" ref="product.product_search_form_view"/>
+        <record id="product_template_tag_search_inherit" model="ir.ui.view">
+            <field name="name">product.template.tag.view.search</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_search_view"/>
             <field name="arch" type="xml">
                 <field name="name" position="after">
-                    <field name="tag_ids" string="Tags" filter_domain="[('tag_ids','ilike',self)]"/>
+                    <field name="tag_ids" string="Tags" filter_domain="['|',('tag_ids','ilike',self),('tag_ids','child_of',self)]"/>
                 </field>
             </field>
         </record>
 
-        <record id="product_product_form_inherit" model="ir.ui.view">
-            <field name="name">product.product.view.form</field>
-            <field name="model">product.product</field>
-            <field name="inherit_id" ref="product.product_normal_form_view"/>
+        <record id="product_template_form_inherit" model="ir.ui.view">
+            <field name="name">product.template.view.form</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_form_view"/>
             <field name="arch" type="xml">
-                <field name="name" position="after">
+                <xpath expr="//h1" position="after">
                     <field name="tag_ids" widget="many2many_tags" placeholder="Tags..."/>
-                </field>
+                </xpath>
             </field>
         </record>
 
 		<!--  kanban view   -->
 
-       	<record model="ir.ui.view" id="product_product_kanban">
-            <field name="name">Product Product Tag Kanban</field>
-            <field name="model">product.product</field>
-            <field name="inherit_id" ref="product.product_kanban_view"/>
+        <record model="ir.ui.view" id="product_template_kanban">
+            <field name="name">Product Template Tag Kanban</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="product.product_template_kanban_view"/>
             <field name="arch" type="xml">
                 <div name="tags" position="inside">
                     <ul>

--- a/product_tags/product_view.xml
+++ b/product_tags/product_view.xml
@@ -10,7 +10,7 @@
                     <group col="4">
                         <field name="name"/>
                         <field name="active"/>
-                        <field name="parent"/>
+                        <field name="parent_id"/>
                     </group>
                 </form>
             </field>


### PR DESCRIPTION
Hi,
we recently needed product tags (with some improvements) in 8.0, so I went ahead and finished the port, including the new api use. While this is a pull request, this module is generic enough that it might make sense to propose it to the OCA, something I cannot do without your permission:
- the code carries GPLv3 copyright notices, while leveraging features of OpenERP that only appeared after it had switched to AGPL, which I believe is a result of an unintentional copy-and-paste error on your side, therefore it is included in this pull request and not a separate one.

If you agree with me that it would be worthwhile to have this adopted in the OCA repositories, I'm happy to go through the steps required to make it happen.