### PR TITLE
partner_history port to 8.0

### DIFF
--- a/partner_history/partner.py
+++ b/partner_history/partner.py
@@ -25,38 +25,90 @@ from openerp.tools.translate import _
 from openerp.tools import ustr
 
 
-class mail_message(orm.Model):
+class mail_message(models.Model):
     _inherit = 'mail.message'
 
-    def compute_partner(self, cr, uid, active_model='res.partner', model='mail.message', res_id=1, context=None):
+    def compute_partner(
+        self, cr, uid,
+        active_model='res.partner', model='mail.message', res_id=1,
+        context=None
+    ):
+        """
+        Finds all 'active_model' references in 'model/res_id' instance
+        """
+
         if context is None:
             context = {}
-        target_ids = []
-        current_obj = self.pool.get(model)
-        cr.execute("SELECT name FROM ir_model_fields WHERE relation='" + active_model + "' and model = '" + model + "' and ttype not in ('many2many', 'one2many');")
-        for name in cr.fetchall():
-            current_data = current_obj.read(cr, uid, res_id, [str(name[0])],context=context)
-            if current_data.get(str(name[0])):
-                var = current_data.get(str(name[0]))
-                if var:
-                    target_ids.append(var[0])
 
-        cr.execute("select name, model from ir_model_fields where relation='" + model + "' and ttype in ('many2many') and model = '" + active_model + "';")
-        for field, model in cr.fetchall():
-            field_data = self.pool.get(model) and self.pool.get(model)._columns.get(field, False) \
-                            and (isinstance(self.pool.get(model)._columns[field], fields.many2many) \
-                            or isinstance(self.pool.get(model)._columns[field], fields.function) \
-                            and self.pool.get(model)._columns[field].store) \
-                            and self.pool.get(model)._columns[field] \
-                            or False
-            if field_data:
-                model_m2m, rel1, rel2 = field_data._sql_names(self.pool.get(model))
-                requete = "SELECT "+rel1+" FROM "+ model_m2m+" WHERE "+ rel2+" ="+str(res_id)+";"
-                cr.execute(requete)
-                sec_target_ids = cr.fetchall()
-                for sec_target_id in sec_target_ids:
-                    target_ids.append(sec_target_id[0])
-        return target_ids
+        target_ids = set()
+
+        # Check references directly in message table (many2one and one2one).
+
+        current_obj = self.pool.get(model)
+        cr.execute((
+            "SELECT name FROM ir_model_fields WHERE relation='{active_model}' "
+            "and model = '{model}' and ttype not in ('many2many', 'one2many');"
+        ).format(active_model=active_model, model=model))
+
+        for name in cr.fetchall():
+            name = str(name[0])
+            current_data = current_obj.read(
+                cr, uid, res_id, [name], context=context)
+
+            var = current_data.get(name)
+
+            if var:
+                target_ids.add(var[0])
+
+        # Check references in 'active_model' m2m relation
+        # tables pointing to model/res_id
+
+        current_obj = self.pool.get(active_model)
+
+        cr.execute((
+            "select name from ir_model_fields where relation='{model}' "
+            " and ttype in ('many2many') and model='{active_model}';"
+        ).format(active_model=active_model, model=model))
+
+        for field in cr.fetchall():
+
+            field = str(field[0])
+
+            if not current_obj:
+                continue
+
+            column = current_obj._columns.get(field)
+
+            if not column or not (
+                isinstance(column, fields.Many2many)
+                or isinstance(column, osv_fields.many2many)
+                or isinstance(column, osv_fields.function)
+                    and column.store
+            ):
+                continue
+
+            field_data = current_obj._columns[fcomield]
+
+            if not field_data:
+                continue
+
+            # Read from the m2m relation table
+
+            model_m2m, rel1, rel2 = field_data._sql_names(current_obj)
+            requete = (
+                "SELECT {rel1} FROM {model_m2m} WHERE {rel2}={res_id};"
+            ).format(
+                rel1=rel1,
+                model_m2m=model_m2m,
+                rel2=rel2,
+                res_id=res_id)
+
+            cr.execute(requete)
+            sec_target_ids = cr.fetchall()
+            for sec_target_id in sec_target_ids:
+                target_ids.add(sec_target_id[0])
+
+        return list(target_ids)
 
     @api.depends('model')
     def _get_object_name(self):

--- a/partner_history/partner.py
+++ b/partner_history/partner.py
@@ -38,7 +38,7 @@ class mail_message(orm.Model):
                 var = current_data.get(str(name[0]))
                 if var:
                     target_ids.append(var[0])
-                    
+
         cr.execute("select name, model from ir_model_fields where relation='" + model + "' and ttype in ('many2many') and model = '" + active_model + "';")
         for field, model in cr.fetchall():
             field_data = self.pool.get(model) and self.pool.get(model)._columns.get(field, False) \
@@ -55,7 +55,7 @@ class mail_message(orm.Model):
                 for sec_target_id in sec_target_ids:
                     target_ids.append(sec_target_id[0])
         return target_ids
-    
+
     def _get_object_name(self, cr, uid, ids, field_name, arg, context=None):
         if context is None:
             context = {}
@@ -67,7 +67,7 @@ class mail_message(orm.Model):
                 model_name = model_obj.browse(cr, uid, model_ids[0], context=context).name
                 result[message.id] = model_name
         return result
-    
+
     def _get_body_txt(self, cr, uid, ids, field_name, arg, context=None):
         if context is None:
             context = {}
@@ -83,15 +83,15 @@ class mail_message(orm.Model):
                     body_txt = record_data.name
                 result[message.id] = body_txt
         return result
-    
+
     _columns = {
         'partner_ids': fields.many2many('res.partner', 'message_partner_rel', 'message_id', 'partner_id', 'Partners'),
         'object_name': fields.function(_get_object_name, type='char', string='Object Name', size=64, store=True),
         'body_txt': fields.function(_get_body_txt, type='text', string='Content', store=True),
     }
-    
+
     _order= 'date desc'
-    
+
     def create(self, cr, uid, vals, context=None):
         if not vals.get('partner_ids'):
             target_ids = []
@@ -103,7 +103,7 @@ class mail_message(orm.Model):
 
 class res_partner(orm.Model):
     _inherit = 'res.partner'
-    
+
     def _get_message(self, cr, uid, ids, field_name, arg, context=None):
         if context is None:
             context = {}
@@ -116,7 +116,7 @@ class res_partner(orm.Model):
                 ], order='date desc', context=context)
             result[partner.id] = target_ids
         return result
-    
+
     _columns = {
         # History follow-up #
         'history_ids': fields.function(_get_message, type='many2many', relation="mail.message", string="Related Messages"),

--- a/partner_history/partner.py
+++ b/partner_history/partner.py
@@ -87,7 +87,7 @@ class mail_message(models.Model):
             ):
                 continue
 
-            field_data = current_obj._columns[fcomield]
+            field_data = current_obj._columns[field]
 
             if not field_data:
                 continue

--- a/partner_history/partner.py
+++ b/partner_history/partner.py
@@ -19,9 +19,11 @@
 #
 #################################################################################
 
-from openerp.osv import fields, orm
+from openerp import models, fields, api
+from openerp.osv import fields as osv_fields
 from openerp.tools.translate import _
 from openerp.tools import ustr
+
 
 class mail_message(orm.Model):
     _inherit = 'mail.message'
@@ -101,25 +103,16 @@ class mail_message(orm.Model):
             vals.update({'partner_ids': [(6, 0, target_ids)],})
         return super(mail_message, self).create(cr, uid, vals, context=context)
 
-class res_partner(orm.Model):
+
+class res_partner(models.Model):
     _inherit = 'res.partner'
 
-    def _get_message(self, cr, uid, ids, field_name, arg, context=None):
-        if context is None:
-            context = {}
-        result = {}
-        message_obj = self.pool.get('mail.message')
-        for partner in self.browse(cr, uid, ids, context=context):
-            target_ids = message_obj.search(cr, uid, [
-                    '|',('partner_ids', 'in', partner.id),
-                    '&',('model', '=', 'res.partner'),('res_id','=',partner.id)
-                ], order='date desc', context=context)
-            result[partner.id] = target_ids
-        return result
+    # Fields
 
-    _columns = {
-        # History follow-up #
-        'history_ids': fields.function(_get_message, type='many2many', relation="mail.message", string="Related Messages"),
-    }
+    history_ids = fields.Many2many(
+        'mail.message',
+        'message_partner_rel', 'partner_id', 'message_id',
+        'Related Messages'
+    )
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:

--- a/partner_history/partner.xml
+++ b/partner_history/partner.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <openerp>
-	<data>
-	
+    <data>
        <record id="view_partner_form_history" model="ir.ui.view">
             <field name="name">res.partner.form.history</field>
             <field name="model">res.partner</field>
             <field name="inherit_id" ref="base.view_partner_form"/>
             <field name="arch" type="xml">
-                <page string="History" position="after">
+                <notebook position="inside">
                     <page string="Flat History">
                         <div class="oe_chatter">
                             <field name="history_ids">
@@ -21,9 +20,8 @@
                             </field>
                         </div>
                     </page>
-                </page>
+                </notebook>
             </field>
         </record>
-
-	</data>
+    </data>
 </openerp>


### PR DESCRIPTION
This pull request contains necessary changes to make the package run in our Odoo 8.0 project.
Included small improvements without changing the observed behavior

- Safer view update if History page is not present
- Use of more recent Odoo api
- Silencing some PEP8 warnings
- Did some code simplifications for mail_message.compute_partner and res_partner.history_ids

Note: In our project the 'm2m relation table' part of the compute_partner implementation was not necessary. Some ad hoc changes were done to test that part. It might be best to test this with a known test case.
