### PR TITLE
[Fix] in Many2many fields column1 should point to these records and column2 to those.

### DIFF
--- a/product_tags/product.py
+++ b/product_tags/product.py
@@ -68,7 +68,7 @@ class product_template(models.Model):
     tag_ids = fields.Many2many(string='Tags',
                                comodel_name='product.tag',
                                relation='product_product_tag_rel',
-                               column1='tag_id',
-                               column2='product_id')
+                               column1='product_id',
+                               column2='tag_id',)
 
 # vim:expandtab:smartindent:tabstop=4:softtabstop=4:shiftwidth=4:


### PR DESCRIPTION
The order of the column parameter in reversed. See Odoo ORM documentation.